### PR TITLE
Fix Docker build by removing non-existent /root/.local copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
  
-COPY --from=uv /root/.local /root/.local
-COPY --from=uv --chown=app:app /app/.venv /app/.venv
+COPY --from=uv /app/.venv /app/.venv
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes this error:
```
docker build -t mcp-server-sparql .
[+] Building 20.0s (15/16)                                                                                                                           docker:rancher-desktop
 => [internal] load build definition from Dockerfile                                                                                                                   0.0s
 => => transferring dockerfile: 1.32kB                                                                                                                                 0.0s
 => [internal] load metadata for ghcr.io/astral-sh/uv:python3.12-bookworm-slim                                                                                         1.8s
 => [internal] load metadata for docker.io/library/python:3.12-slim-bookworm                                                                                           1.5s
 => [auth] library/python:pull token for registry-1.docker.io                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                      1.0s
 => => transferring context: 61.04MB                                                                                                                                   1.0s
 => [uv 1/5] FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:235c2e8419851c1d539e2b19033d56aaf82670bfaaa155e20ac6b21260dc0be9                               11.7s
 => => resolve ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:235c2e8419851c1d539e2b19033d56aaf82670bfaaa155e20ac6b21260dc0be9                                   0.0s
 => => sha256:235c2e8419851c1d539e2b19033d56aaf82670bfaaa155e20ac6b21260dc0be9 2.22kB / 2.22kB                                                                         0.0s
 => => sha256:729eb4333f429be6cefcf16ab65048972a2dbaa351b263703e1706c00af680c5 1.25kB / 1.25kB                                                                         0.0s
 => => sha256:c12e339de29e2b53c81bcdb1e5f54c7ea46381a913d8a7b7130fcec1a005f281 6.64kB / 6.64kB                                                                         0.0s
 => => sha256:37259e7330667afd74c3386d3ed869f06bd9b7714370c78e3065f4e28607cc02 28.08MB / 28.08MB                                                                       4.9s
 => => sha256:6e88b4602d856d9c6fd77c5ce5fc92d0fd2b235bde9fcf47cd0b39a63e49cd85 3.34MB / 3.34MB                                                                         4.3s
 => => sha256:ece23617e8058f25975eac21f88369a14304b84b557f53161638257397c57e9c 13.59MB / 13.59MB                                                                      10.5s
 => => sha256:df0f7b304e58b13ccd54ca61f4686364da2f999d17b206d5c46b0819bc07eaac 249B / 249B                                                                             4.6s
 => => sha256:a75036336233f51bb08cb121be28d7327b40078056c6c3e5dca133a4a99555a1 17.58MB / 17.58MB                                                                       8.9s
 => => extracting sha256:37259e7330667afd74c3386d3ed869f06bd9b7714370c78e3065f4e28607cc02                                                                              1.5s
 => => extracting sha256:6e88b4602d856d9c6fd77c5ce5fc92d0fd2b235bde9fcf47cd0b39a63e49cd85                                                                              0.1s
 => => extracting sha256:ece23617e8058f25975eac21f88369a14304b84b557f53161638257397c57e9c                                                                              0.7s
 => => extracting sha256:a75036336233f51bb08cb121be28d7327b40078056c6c3e5dca133a4a99555a1                                                                              0.3s
 => [stage-1 1/5] FROM docker.io/library/python:3.12-slim-bookworm@sha256:4600f71648e110b005bf7bca92dbb335e549e6b27f2e83fceee5e11b3e1a4d01                            11.3s
 => => resolve docker.io/library/python:3.12-slim-bookworm@sha256:4600f71648e110b005bf7bca92dbb335e549e6b27f2e83fceee5e11b3e1a4d01                                     0.0s
 => => sha256:c726772ed8339a2d7c4d67e1b5806b305282d3491f190d1762948d8a64da4a34 5.59kB / 5.59kB                                                                         0.0s
 => => sha256:37259e7330667afd74c3386d3ed869f06bd9b7714370c78e3065f4e28607cc02 28.08MB / 28.08MB                                                                       4.9s
 => => sha256:6e88b4602d856d9c6fd77c5ce5fc92d0fd2b235bde9fcf47cd0b39a63e49cd85 3.34MB / 3.34MB                                                                         4.3s
 => => sha256:ece23617e8058f25975eac21f88369a14304b84b557f53161638257397c57e9c 13.59MB / 13.59MB                                                                      10.5s
 => => sha256:4600f71648e110b005bf7bca92dbb335e549e6b27f2e83fceee5e11b3e1a4d01 9.13kB / 9.13kB                                                                         0.0s
 => => sha256:af15cbf55c52d715048043201770f2b39888fa6ead51b2398d12a267ba945ae7 1.75kB / 1.75kB                                                                         0.0s
 => => sha256:df0f7b304e58b13ccd54ca61f4686364da2f999d17b206d5c46b0819bc07eaac 249B / 249B                                                                             4.6s
 => => extracting sha256:37259e7330667afd74c3386d3ed869f06bd9b7714370c78e3065f4e28607cc02                                                                              1.5s
 => => extracting sha256:6e88b4602d856d9c6fd77c5ce5fc92d0fd2b235bde9fcf47cd0b39a63e49cd85                                                                              0.1s
 => => extracting sha256:ece23617e8058f25975eac21f88369a14304b84b557f53161638257397c57e9c                                                                              0.7s
 => => extracting sha256:df0f7b304e58b13ccd54ca61f4686364da2f999d17b206d5c46b0819bc07eaac                                                                              0.0s
 => CANCELED [stage-1 2/5] RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*                                                                 6.9s
 => [uv 2/5] WORKDIR /app                                                                                                                                              0.3s
 => [uv 3/5] RUN --mount=type=cache,target=/root/.cache/uv     --mount=type=bind,source=uv.lock,target=uv.lock     --mount=type=bind,source=pyproject.toml,target=pyp  3.3s
 => [uv 4/5] ADD . /app                                                                                                                                                0.9s
 => [uv 5/5] RUN --mount=type=cache,target=/root/.cache/uv     uv sync --frozen --no-dev --no-editable                                                                 1.9s
 => CACHED [stage-1 3/5] WORKDIR /app                                                                                                                                  0.0s
 => ERROR [stage-1 4/5] COPY --from=uv /root/.local /root/.local                                                                                                       0.0s
------                                                                                                                                                                      
 > [stage-1 4/5] COPY --from=uv /root/.local /root/.local:                                                                                                                  
------                                                                                                                                                                      
Dockerfile:31                                                                                                                                                               
--------------------                                                                                                                                                        
  29 |     WORKDIR /app                                                                                                                                                     
  30 |                                                                                                                                                                      
  31 | >>> COPY --from=uv /root/.local /root/.local                                                                                                                         
  32 |     COPY --from=uv --chown=app:app /app/.venv /app/.venv                                                                                                             
  33 |                                                                                                                                                                      
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref c5dd5a3b-2603-4df4-b4d4-4896bc7a02bc::0ptnhd797icw8pssxr4ct0d9z: "/root/.local": not found
```